### PR TITLE
Fix an author test (xt/05_saba.t)

### DIFF
--- a/xt/05_saba.t
+++ b/xt/05_saba.t
@@ -12,7 +12,7 @@ for (
     $node;
     $node = $node->next
 ) {
-    is decode_utf8($node->surface), shift @expect;
+    is decode(Text::MeCab::ENCODING, $node->surface), shift @expect;
 }
 
 done_testing;


### PR DESCRIPTION
I used euc-jp dictionary and xt/05_saba.t was failed.
I changed specified encodings of return values.
