### PR TITLE
carton使用時にencodingを指定する方法を追加

### DIFF
--- a/tools/probe_mecab.pl
+++ b/tools/probe_mecab.pl
@@ -5,7 +5,9 @@ use File::Spec;
 use Getopt::Long;
 use ExtUtils::MakeMaker ();
 
-my $default_encoding = 'euc-jp';
+# May specify encoding from ENV
+my $default_encoding = $ENV{PERL_TEXT_MECAB_ENCODING} || 'euc-jp';
+
 my $default_config;
 if (! GetOptions(
     "encoding=s" => \$default_encoding,


### PR DESCRIPTION
carton install Text::MeCab 実行時に、環境変数PERL_TEXT_MECAB_ENCODINGにencoding(utf-8,euc-jp, etc...)を設定しておくことで、encodingの指定をできるようにしました。
