### PR TITLE
Compilation fail with libmecab under 0.98

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -37,6 +37,10 @@ my $config = run_probes();
 check_lib($config);
 define_symbols($config);
 
+do 'tools/genfiles.pl';
+die if $@;
+MeCabBuild::write_files($config->{version});
+
 name 'Text-MeCab';
 all_from 'lib/Text/MeCab.pm';
 

--- a/t/01-sanity.t
+++ b/t/01-sanity.t
@@ -7,14 +7,37 @@ BEGIN
     use_ok("Text::MeCab", ':all');
 }
 
-if (Text::MeCab::MECAB_VERSION() >= 0.90 && Text::MeCab::MECAB_VERSION() <= 0.98) {
-    ok(eval { my $v = MECAB_NOR_NODE; 1 } && !$@, "MECAB_NOR_NODE ok");
-    ok(eval { my $v = MECAB_UNK_NODE; 1 } && !$@, "MECAB_UNK_NODE ok");
-    ok(eval { my $v = MECAB_BOS_NODE; 1 } && !$@, "MECAB_BOS_NODE ok");
-    ok(eval { my $v = MECAB_EOS_NODE; 1 } && !$@, "MECAB_EOS_NODE ok");
+my $version = Text::MeCab::version();
+diag $version;
+
+is $version, Text::MeCab::MECAB_VERSION(), "version ok";
+
+if ($version >= 0.90 && $version <= 0.996) {
+    ok(eval { defined MECAB_NOR_NODE } && !$@, "MECAB_NOR_NODE ok");
+    ok(eval { defined MECAB_UNK_NODE } && !$@, "MECAB_UNK_NODE ok");
+    ok(eval { defined MECAB_BOS_NODE } && !$@, "MECAB_BOS_NODE ok");
+    ok(eval { defined MECAB_EOS_NODE } && !$@, "MECAB_EOS_NODE ok");
 }
 
-diag Text::MeCab::version();
+if ($version >= 0.98 && $version <= 0.996) {
+    ok(eval { defined MECAB_EON_NODE } && !$@, "MECAB_EON_NODE ok");
+}
+
+if ($version >= 0.94 && $version <= 0.996) {
+    ok(eval { defined MECAB_SYS_DIC } && !$@, "MECAB_SYS_DIC ok");
+    ok(eval { defined MECAB_USR_DIC } && !$@, "MECAB_USR_DIC ok");
+    ok(eval { defined MECAB_UNK_DIC } && !$@, "MECAB_UNK_DIC ok");
+}
+
+if ($version >= 0.99 && $version <= 0.996) {
+    ok(eval { defined MECAB_ONE_BEST      } && !$@, "MECAB_ONE_BEST ok");
+    ok(eval { defined MECAB_NBEST         } && !$@, "MECAB_NBEST ok");
+    ok(eval { defined MECAB_PARTIAL       } && !$@, "MECAB_PARTIAL ok");
+    ok(eval { defined MECAB_MARGINAL_PROB } && !$@, "MECAB_MARGINAL_PROB ok");
+    ok(eval { defined MECAB_ALTERNATIVE   } && !$@, "MECAB_ALTERNATIVE ok");
+    ok(eval { defined MECAB_ALL_MORPHS    } && !$@, "MECAB_ALL_MORPHS ok");
+    ok(eval { defined MECAB_ALLOCATE_SENTENCE } && !$@, "MECAB_ALLOCATE_SENTENCE ok");
+}
 
 can_ok("Text::MeCab", qw(new parse));
 

--- a/tools/genfiles.pl
+++ b/tools/genfiles.pl
@@ -1,0 +1,74 @@
+use strict;
+use warnings;
+
+package MeCabBuild;
+
+sub write_files {
+    my $version = shift;
+
+    write_config_const($version);
+}
+
+sub write_config_const {
+    my ($version) = @_;
+
+    my $contents;
+    if ($version >= 0.99) {
+        $contents = config_const_from_enum();
+    } else {
+        $contents = config_const_from_symbol();
+    }
+
+    open my $f, '>', 'xs/config-const.h'
+        or die "Could not open file: $!";
+    print $f $contents;
+    close $f;
+}
+
+my @const_names = qw(
+    MECAB_NOR_NODE
+    MECAB_UNK_NODE
+    MECAB_BOS_NODE
+    MECAB_EOS_NODE
+    MECAB_EON_NODE
+
+    MECAB_SYS_DIC
+    MECAB_USR_DIC
+    MECAB_UNK_DIC
+
+    MECAB_ONE_BEST
+    MECAB_NBEST
+    MECAB_PARTIAL
+    MECAB_MARGINAL_PROB
+    MECAB_ALTERNATIVE
+    MECAB_ALL_MORPHS
+    MECAB_ALLOCATE_SENTENCE
+);
+
+# for >= 0.99
+sub config_const_from_enum {
+    my $contents = "";
+
+    foreach my $name (@const_names) {
+        $contents .= <<"END_TEMPLATE";
+#define HAVE_$name 1
+END_TEMPLATE
+    }
+
+    return $contents;
+}
+
+# for <= 0.98
+sub config_const_from_symbol {
+    my $contents = "";
+
+    foreach my $name (@const_names) {
+        $contents .= <<"END_TEMPLATE";
+#ifdef $name
+#define HAVE_$name 1
+#endif
+END_TEMPLATE
+    }
+
+    return $contents;
+}

--- a/xs/MeCab.xs
+++ b/xs/MeCab.xs
@@ -64,6 +64,59 @@ static MGVTBL TextMeCab_vtbl = { /* for identity */
     NULL,  /* local */
 };
 
+static void
+register_constants()
+{
+    HV *stash = gv_stashpv("Text::MeCab", TRUE);
+
+#ifdef MECAB_NOR_NODE
+    newCONSTSUB(stash, "MECAB_NOR_NODE", newSViv(MECAB_NOR_NODE));
+#endif
+#ifdef MECAB_UNK_NODE
+    newCONSTSUB(stash, "MECAB_UNK_NODE", newSViv(MECAB_UNK_NODE));
+#endif
+#ifdef MECAB_BOS_NODE
+    newCONSTSUB(stash, "MECAB_BOS_NODE", newSViv(MECAB_BOS_NODE));
+#endif
+#ifdef MECAB_EOS_NODE
+    newCONSTSUB(stash, "MECAB_EOS_NODE", newSViv(MECAB_EOS_NODE));
+#endif
+#ifdef MECAB_EON_NODE
+    newCONSTSUB(stash, "MECAB_EON_NODE", newSViv(MECAB_EON_NODE));
+#endif
+
+#ifdef MECAB_SYS_DIC
+    newCONSTSUB(stash, "MECAB_SYS_DIC", newSViv(MECAB_SYS_DIC));
+#endif
+#ifdef MECAB_USR_DIC
+    newCONSTSUB(stash, "MECAB_USR_DIC", newSViv(MECAB_USR_DIC));
+#endif
+#ifdef MECAB_UNK_DIC
+    newCONSTSUB(stash, "MECAB_UNK_DIC", newSViv(MECAB_UNK_DIC));
+#endif
+
+#ifdef MECAB_ONE_BEST
+    newCONSTSUB(stash, "MECAB_ONE_BEST",      newSViv(MECAB_ONE_BEST));
+#endif
+#ifdef MECAB_NBEST
+    newCONSTSUB(stash, "MECAB_NBEST",         newSViv(MECAB_NBEST));
+#endif
+#ifdef MECAB_PARTIAL
+    newCONSTSUB(stash, "MECAB_PARTIAL",       newSViv(MECAB_PARTIAL));
+#endif
+#ifdef MECAB_MARGINAL_PROB
+    newCONSTSUB(stash, "MECAB_MARGINAL_PROB", newSViv(MECAB_MARGINAL_PROB));
+#endif
+#ifdef MECAB_ALTERNATIVE
+    newCONSTSUB(stash, "MECAB_ALTERNATIVE",   newSViv(MECAB_ALTERNATIVE));
+#endif
+#ifdef MECAB_ALL_MORPHS
+    newCONSTSUB(stash, "MECAB_ALL_MORPHS",    newSViv(MECAB_ALL_MORPHS));
+#endif
+#ifdef MECAB_ALLOCATE_SENTENCE
+    newCONSTSUB(stash, "MECAB_ALLOCATE_SENTENCE", newSViv(MECAB_ALLOCATE_SENTENCE));
+#endif
+}
 
 
 MODULE = Text::MeCab    PACKAGE = Text::MeCab    PREFIX = TextMeCab_
@@ -72,29 +125,7 @@ PROTOTYPES: DISABLE
 
 BOOT:
     TextMeCab_bootstrap();
-
-IV
-constant()
-    ALIAS:
-        MECAB_NOR_NODE = MECAB_NOR_NODE
-        MECAB_UNK_NODE = MECAB_UNK_NODE
-        MECAB_BOS_NODE = MECAB_BOS_NODE
-        MECAB_EOS_NODE = MECAB_EOS_NODE
-        MECAB_EON_NODE = MECAB_EON_NODE
-        MECAB_SYS_DIC  = MECAB_SYS_DIC
-        MECAB_USR_DIC  = MECAB_USR_DIC
-        MECAB_UNK_DIC  = MECAB_UNK_DIC
-        MECAB_ONE_BEST = MECAB_ONE_BEST
-        MECAB_NBEST    = MECAB_NBEST
-        MECAB_PARTIAL  = MECAB_PARTIAL
-        MECAB_MARGINAL_PROB = MECAB_MARGINAL_PROB
-        MECAB_ALTERNATIVE = MECAB_ALTERNATIVE
-        MECAB_ALL_MORPHS = MECAB_ALL_MORPHS
-        MECAB_ALLOCATE_SENTENCE = MECAB_ALLOCATE_SENTENCE
-    CODE:
-        RETVAL = ix;
-    OUTPUT:
-        RETVAL
+    register_constants();
 
 TextMeCab *
 TextMeCab__xs_create(class_sv, args = NULL)

--- a/xs/MeCab.xs
+++ b/xs/MeCab.xs
@@ -1,4 +1,5 @@
 #include "text-mecab.h"
+#include "config-const.h"
 
 static int
 TextMeCab_mg_free(pTHX_ SV *const sv, MAGIC* const mg)
@@ -69,51 +70,51 @@ register_constants()
 {
     HV *stash = gv_stashpv("Text::MeCab", TRUE);
 
-#ifdef MECAB_NOR_NODE
+#if HAVE_MECAB_NOR_NODE
     newCONSTSUB(stash, "MECAB_NOR_NODE", newSViv(MECAB_NOR_NODE));
 #endif
-#ifdef MECAB_UNK_NODE
+#if HAVE_MECAB_UNK_NODE
     newCONSTSUB(stash, "MECAB_UNK_NODE", newSViv(MECAB_UNK_NODE));
 #endif
-#ifdef MECAB_BOS_NODE
+#if HAVE_MECAB_BOS_NODE
     newCONSTSUB(stash, "MECAB_BOS_NODE", newSViv(MECAB_BOS_NODE));
 #endif
-#ifdef MECAB_EOS_NODE
+#if HAVE_MECAB_EOS_NODE
     newCONSTSUB(stash, "MECAB_EOS_NODE", newSViv(MECAB_EOS_NODE));
 #endif
-#ifdef MECAB_EON_NODE
+#if HAVE_MECAB_EON_NODE
     newCONSTSUB(stash, "MECAB_EON_NODE", newSViv(MECAB_EON_NODE));
 #endif
 
-#ifdef MECAB_SYS_DIC
+#if HAVE_MECAB_SYS_DIC
     newCONSTSUB(stash, "MECAB_SYS_DIC", newSViv(MECAB_SYS_DIC));
 #endif
-#ifdef MECAB_USR_DIC
+#if HAVE_MECAB_USR_DIC
     newCONSTSUB(stash, "MECAB_USR_DIC", newSViv(MECAB_USR_DIC));
 #endif
-#ifdef MECAB_UNK_DIC
+#if HAVE_MECAB_UNK_DIC
     newCONSTSUB(stash, "MECAB_UNK_DIC", newSViv(MECAB_UNK_DIC));
 #endif
 
-#ifdef MECAB_ONE_BEST
+#if HAVE_MECAB_ONE_BEST
     newCONSTSUB(stash, "MECAB_ONE_BEST",      newSViv(MECAB_ONE_BEST));
 #endif
-#ifdef MECAB_NBEST
+#if HAVE_MECAB_NBEST
     newCONSTSUB(stash, "MECAB_NBEST",         newSViv(MECAB_NBEST));
 #endif
-#ifdef MECAB_PARTIAL
+#if HAVE_MECAB_PARTIAL
     newCONSTSUB(stash, "MECAB_PARTIAL",       newSViv(MECAB_PARTIAL));
 #endif
-#ifdef MECAB_MARGINAL_PROB
+#if HAVE_MECAB_MARGINAL_PROB
     newCONSTSUB(stash, "MECAB_MARGINAL_PROB", newSViv(MECAB_MARGINAL_PROB));
 #endif
-#ifdef MECAB_ALTERNATIVE
+#if HAVE_MECAB_ALTERNATIVE
     newCONSTSUB(stash, "MECAB_ALTERNATIVE",   newSViv(MECAB_ALTERNATIVE));
 #endif
-#ifdef MECAB_ALL_MORPHS
+#if HAVE_MECAB_ALL_MORPHS
     newCONSTSUB(stash, "MECAB_ALL_MORPHS",    newSViv(MECAB_ALL_MORPHS));
 #endif
-#ifdef MECAB_ALLOCATE_SENTENCE
+#if HAVE_MECAB_ALLOCATE_SENTENCE
     newCONSTSUB(stash, "MECAB_ALLOCATE_SENTENCE", newSViv(MECAB_ALLOCATE_SENTENCE));
 #endif
 }


### PR DESCRIPTION
Compilation with older libmecab fails because some constants in `constant()` are not defined in it.
With this patch, available constants only will be defined.

For more information, please refer to issue #8.
